### PR TITLE
Update instructions and an include statement for failing build, closes #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Installation
         ./configure
         make
         sudo make install
+        sudo ldconfig
 
 <a name="autotools-installation"></a>
 ### Building with autotools (Linux / Unix / BSD / Mac OS X)

--- a/src/DeltaException.cpp
+++ b/src/DeltaException.cpp
@@ -5,6 +5,7 @@
 #endif
 
 #include <cstring>
+#include <ctime>
 #include <errno.h>
 #include <stdarg.h>
 


### PR DESCRIPTION
Closes #9
Not much was required to make this work on vanilla Ubuntu 22.10
It might be nice to have a new release to bring this up to date.